### PR TITLE
Fix that prevents JSON-RPC connection from being opened in tests.

### DIFF
--- a/src/check-reserve-update-frequency/check-reserve-update-frequency.js
+++ b/src/check-reserve-update-frequency/check-reserve-update-frequency.js
@@ -114,11 +114,11 @@ function provideHandleBlock(tokensAddressesContractsPromise) {
   return async function handleBlock(blockEvent) {
     const findings = [];
 
-    // settle the promise the first time, all subsequent times just get the resolve() value
-    const tokensAddressesContracts = await tokensAddressesContractsPromise;
-
     // get the timestamp for the current block
     const blockTimestamp = new BigNumber(blockEvent.block.timestamp);
+
+    // settle the promise the first time, all subsequent times just get the resolve() value
+    const tokensAddressesContracts = await tokensAddressesContractsPromise();
 
     // override block number so we get data from the block in question
     const override = { blockTag: blockEvent.blockNumber };
@@ -164,6 +164,6 @@ function provideHandleBlock(tokensAddressesContractsPromise) {
 
 module.exports = {
   provideHandleBlock,
-  handleBlock: provideHandleBlock(initializeTokensContracts()),
+  handleBlock: provideHandleBlock(initializeTokensContracts),
   createAlert,
 };


### PR DESCRIPTION
Previously, when the agent module was imported into tests, the initialization function was automatically run, opening up a JSON-RPC channel.  The Promise associated with the initialization function is not handled during the tests (it's not used by the tests), causing Jest to produce warnings and errors about unhandled Promise results.

This fix prevents that channel from being opened upon import but does not change the functionality of the agent module for production.