### PR TITLE
Fixing bug that would cause check-reserve-update-frequency tests to not cleanly exit

### DIFF
--- a/src/check-reserve-update-frequency/agent-setup.js
+++ b/src/check-reserve-update-frequency/agent-setup.js
@@ -1,0 +1,105 @@
+const ethers = require('ethers');
+const {
+  Finding, FindingSeverity, FindingType, getJsonRpcUrl,
+} = require('forta-agent');
+
+// load required shared types
+const {
+  LendingPoolAddressesProvider: lendingPoolAddressesProvider,
+  ProtocolDataProvider: protocolDataProviderAddress,
+} = require('../../contract-addresses.json');
+const { abi: protocolDataProviderAbi } = require('../../abi/AaveProtocolDataProvider.json');
+const { abi: aaveOracleAbi } = require('../../abi/AaveOracle.json');
+const { abi: chainlinkAggregatorAbi } = require('../../abi/AggregatorV3Interface.json');
+const { abi: lendingPoolAddressesProviderAbi } = require('../../abi/ILendingPoolAddressesProvider.json');
+
+const { aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
+
+// set up the an ethers provider
+// use ethers.providers.JsonRpcProvider() in lieu of ethers.providers.WebSocketProvider()
+// websockets are not supported in production
+const jsonRpcProvider = new ethers.providers.JsonRpcProvider(getJsonRpcUrl());
+
+// there are several reserve tokens in AAVE that do not use Chainlink price oracles
+// we will filter these out before we attempt to determine the age of the oracle data
+// Gemini Dollar uses ExtendedGusdPriceProxy source: 0xEc6f4Cd64d28Ef32507e2dc399948aAe9Bbedd7e
+// xSUSHI Token uses XSushiPriceAdapter source: 0x9b26214bEC078E68a394AaEbfbffF406Ce14893F
+// Wrapped Ether uses Black Hole source: 0x0000000000000000000000000000000000000000
+const TOKENS_WITHOUT_CHAINLINK_ABI = [
+  '0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd', // Gemini Dollar
+  '0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272', // xSUSHI Token
+  '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // Wrapped Ether
+];
+
+// helper function to create alerts
+function createAlert(reserveToken, oracleAge, priceSourceAddress) {
+  return Finding.fromObject({
+    name: `Stale AAVE Price Oracle Data for ${reserveToken.symbol}`,
+    description: `Token ${reserveToken.symbol} Price Oracle Age: ${oracleAge} seconds`,
+    alertId: 'AE-AAVE-PRICE-ORACLE-STALE',
+    severity: FindingSeverity.Medium,
+    type: FindingType.Degraded,
+    everestId: AAVE_EVEREST_ID,
+    metadata: {
+      symbol: reserveToken.symbol,
+      tokenAddress: reserveToken.tokenAddress,
+      oracleAge,
+      priceSourceAddress,
+    },
+  });
+}
+
+async function initializeTokensContracts() {
+  // create instances of ethers contracts to call read-only methods
+  const protocolDataProviderContract = new ethers.Contract(
+    protocolDataProviderAddress, protocolDataProviderAbi, jsonRpcProvider,
+  );
+  const lendingPoolAddressProviderContract = new ethers.Contract(
+    lendingPoolAddressesProvider, lendingPoolAddressesProviderAbi, jsonRpcProvider,
+  );
+
+  // get an array of all of the reserve tokens, in the form of TokenData struct entries
+  // ref: https://docs.aave.com/developers/the-core-protocol/protocol-data-provider#getallreservestokens
+  let reserveTokenArray = await protocolDataProviderContract.getAllReservesTokens();
+
+  // remove tokens that do not have Chainlink price oracles
+  reserveTokenArray = reserveTokenArray.filter(
+    (reserveToken) => TOKENS_WITHOUT_CHAINLINK_ABI.indexOf(reserveToken.tokenAddress) === -1,
+  );
+
+  // get the AAVE price oracle address
+  const priceOracleAddress = await lendingPoolAddressProviderContract.getPriceOracle();
+  const priceOracleContractInstance = new ethers.Contract(
+    priceOracleAddress,
+    aaveOracleAbi,
+    jsonRpcProvider,
+  );
+
+  // get the price source addresses
+  const priceSourceAddresses = await Promise.all(reserveTokenArray.map(
+    (reserveToken) => priceOracleContractInstance.getSourceOfAsset(reserveToken.tokenAddress),
+  ));
+
+  // create ethers contracts to run read-only methods from the Chainlink contracts
+  const priceSourceContractInstances = priceSourceAddresses.map(
+    (priceSourceAddress) => new ethers.Contract(
+      priceSourceAddress,
+      chainlinkAggregatorAbi,
+      jsonRpcProvider,
+    ),
+  );
+
+  // create an array of token / address / contract tuples that we will iterate over
+  const tokenAddressContractTuples = reserveTokenArray.map((reserveToken, index) => {
+    const priceSourceAddress = priceSourceAddresses[index];
+    const priceSourceContract = priceSourceContractInstances[index];
+    return { reserveToken, priceSourceAddress, priceSourceContract };
+  });
+
+  return tokenAddressContractTuples;
+}
+
+module.exports = {
+  initializeTokensContracts,
+  createAlert,
+};

--- a/src/check-reserve-update-frequency/check-reserve-update-frequency.js
+++ b/src/check-reserve-update-frequency/check-reserve-update-frequency.js
@@ -1,23 +1,9 @@
 const ethers = require('ethers');
 const BigNumber = require('bignumber.js');
-const {
-  Finding, FindingSeverity, FindingType, getJsonRpcUrl,
-} = require('forta-agent');
 
-// load required shared types
-const {
-  LendingPoolAddressesProvider: lendingPoolAddressesProvider,
-  ProtocolDataProvider: protocolDataProviderAddress,
-} = require('../../contract-addresses.json');
-const { abi: protocolDataProviderAbi } = require('../../abi/AaveProtocolDataProvider.json');
-const { abi: aaveOracleAbi } = require('../../abi/AaveOracle.json');
-const { abi: chainlinkAggregatorAbi } = require('../../abi/AggregatorV3Interface.json');
-const { abi: lendingPoolAddressesProviderAbi } = require('../../abi/ILendingPoolAddressesProvider.json');
+const { checkReserveUpdateFrequency } = require('../../agent-config.json');
 
-const {
-  checkReserveUpdateFrequency,
-  aaveEverestId: AAVE_EVEREST_ID,
-} = require('../../agent-config.json');
+const { initializeTokensContracts, createAlert } = require('./agent-setup');
 
 // time threshold over which we trigger alerts (24 hours = 86400 seconds)
 // NOTE: this value is imported from the agent-config.json file
@@ -25,90 +11,6 @@ const {
 //  'A new trusted answer is written when the off-chain price moves more than the deviation
 //   threshold or 86400 seconds have passed since the last answer was written on-chain.'
 const ORACLE_AGE_THRESHOLD_SECONDS = checkReserveUpdateFrequency.oracleAgeThresholdSeconds;
-
-// set up the an ethers provider
-// use ethers.providers.JsonRpcProvider() in lieu of ethers.providers.WebSocketProvider()
-// websockets are not supported in production
-const jsonRpcProvider = new ethers.providers.JsonRpcProvider(getJsonRpcUrl());
-
-// there are several reserve tokens in AAVE that do not use Chainlink price oracles
-// we will filter these out before we attempt to determine the age of the oracle data
-// Gemini Dollar uses ExtendedGusdPriceProxy source: 0xEc6f4Cd64d28Ef32507e2dc399948aAe9Bbedd7e
-// xSUSHI Token uses XSushiPriceAdapter source: 0x9b26214bEC078E68a394AaEbfbffF406Ce14893F
-// Wrapped Ether uses Black Hole source: 0x0000000000000000000000000000000000000000
-const TOKENS_WITHOUT_CHAINLINK_ABI = [
-  '0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd', // Gemini Dollar
-  '0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272', // xSUSHI Token
-  '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // Wrapped Ether
-];
-
-// helper function to create alerts
-function createAlert(reserveToken, oracleAge, priceSourceAddress) {
-  return Finding.fromObject({
-    name: `Stale AAVE Price Oracle Data for ${reserveToken.symbol}`,
-    description: `Token ${reserveToken.symbol} Price Oracle Age: ${oracleAge} seconds`,
-    alertId: 'AE-AAVE-PRICE-ORACLE-STALE',
-    severity: FindingSeverity.Medium,
-    type: FindingType.Degraded,
-    everestId: AAVE_EVEREST_ID,
-    metadata: {
-      symbol: reserveToken.symbol,
-      tokenAddress: reserveToken.tokenAddress,
-      oracleAge,
-      priceSourceAddress,
-    },
-  });
-}
-
-async function initializeTokensContracts() {
-  // create instances of ethers contracts to call read-only methods
-  const protocolDataProviderContract = new ethers.Contract(
-    protocolDataProviderAddress, protocolDataProviderAbi, jsonRpcProvider,
-  );
-  const lendingPoolAddressProviderContract = new ethers.Contract(
-    lendingPoolAddressesProvider, lendingPoolAddressesProviderAbi, jsonRpcProvider,
-  );
-
-  // get an array of all of the reserve tokens, in the form of TokenData struct entries
-  // ref: https://docs.aave.com/developers/the-core-protocol/protocol-data-provider#getallreservestokens
-  let reserveTokenArray = await protocolDataProviderContract.getAllReservesTokens();
-
-  // remove tokens that do not have Chainlink price oracles
-  reserveTokenArray = reserveTokenArray.filter(
-    (reserveToken) => TOKENS_WITHOUT_CHAINLINK_ABI.indexOf(reserveToken.tokenAddress) === -1,
-  );
-
-  // get the AAVE price oracle address
-  const priceOracleAddress = await lendingPoolAddressProviderContract.getPriceOracle();
-  const priceOracleContractInstance = new ethers.Contract(
-    priceOracleAddress,
-    aaveOracleAbi,
-    jsonRpcProvider,
-  );
-
-  // get the price source addresses
-  const priceSourceAddresses = await Promise.all(reserveTokenArray.map(
-    (reserveToken) => priceOracleContractInstance.getSourceOfAsset(reserveToken.tokenAddress),
-  ));
-
-  // create ethers contracts to run read-only methods from the Chainlink contracts
-  const priceSourceContractInstances = priceSourceAddresses.map(
-    (priceSourceAddress) => new ethers.Contract(
-      priceSourceAddress,
-      chainlinkAggregatorAbi,
-      jsonRpcProvider,
-    ),
-  );
-
-  // create an array of token / address / contract tuples that we will iterate over
-  const tokenAddressContractTuples = reserveTokenArray.map((reserveToken, index) => {
-    const priceSourceAddress = priceSourceAddresses[index];
-    const priceSourceContract = priceSourceContractInstances[index];
-    return { reserveToken, priceSourceAddress, priceSourceContract };
-  });
-
-  return tokenAddressContractTuples;
-}
 
 function provideHandleBlock(tokensAddressesContractsPromise) {
   return async function handleBlock(blockEvent) {
@@ -165,5 +67,4 @@ function provideHandleBlock(tokensAddressesContractsPromise) {
 module.exports = {
   provideHandleBlock,
   handleBlock: provideHandleBlock(initializeTokensContracts()),
-  createAlert,
 };

--- a/src/check-reserve-update-frequency/check-reserve-update-frequency.spec.js
+++ b/src/check-reserve-update-frequency/check-reserve-update-frequency.spec.js
@@ -1,7 +1,22 @@
 // required libraries
 const BigNumber = require('bignumber.js');
 const { createBlockEvent } = require('forta-agent');
-const { provideHandleBlock, createAlert } = require('./check-reserve-update-frequency');
+
+// mock the initializeTokensContracts async function before importing the agent module
+// the agent module will then receive our mocked version of the function
+// if we did not perform this step, we would (intermittently) receive errors during test execution:
+//   'Jest did not exit one second after the test run has completed.'
+// due to the fact that the initializeTokensContracts function is executed whenever any part of the
+// agent module is imported
+// therefore, we must mock that function before the agent module is imported, thereby giving our
+// mocked version of the function to all subsquent imports that use it
+jest.mock('./agent-setup', () => ({
+  ...jest.requireActual('./agent-setup'),
+  initializeTokensContracts: jest.fn().mockResolvedValue(),
+}));
+
+const { createAlert } = require('./agent-setup');
+const { provideHandleBlock } = require('./check-reserve-update-frequency');
 
 describe('AAVE reserve price oracle agent', () => {
   let handleBlock;


### PR DESCRIPTION
### Symptom
The tests for the `check-reserve-update-frequency` agent would run successfully but then intermittently display a message afterwards that stated:
```
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

### Background
This agent uses a function called `initializeTokensContracts`.  The purpose of this function is to run ONCE when the agent is imported to perform several contract interactions:
1. Retrieve an Array of reserve tokens used by AAVE Lending Pools
2. Retrieve the contract address for the AAVE price oracle
3. Set up an ethers.Contract object to interact with the AAVE price oracle contract
4. Call the AAVE price oracle view-only method `getSourceOfAsset` for each reserve token to get the corresponding Chainlink Aggregator contract address
5. Set up ethers.Contract objects for each Chainlink Aggregator contract
6. Return an Array of reserve tokens, Chainlink Aggregator contract addresses, and ethers.Contract objects

The purpose of running these steps once is to ensure a static set of variables that the agent will use for all subsequent alerts.  Managing a potentially changing set of underlying contracts and implementations seems to be outside the scope of what a Scan Agent should do.

The way the `initializeTokensContracts` function is called is when the `handleBlock` export from the agent module is imported into another module:
```javascript
module.exports = {
  provideHandleBlock,
  handleBlock: provideHandleBlock(initializeTokensContracts()),
}
```
The **assumption** here was that any module importing `handleBlock` would receive the return value from `provideHandleBlock()` with the return value from `initializeTokensContracts()` as the only argument.  That argument is then within scope for the returned function `async function handleBlock(blockEvent)`, which is then called by the Scan Agent whenever a new `blockEvent` is available.

### Bug
When importing a module (part or all), Javascript evaluates the entire module.  For reference, see the first few sentences here:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports
If the module has side effects, those side effects will occur when the module is imported, even if only one function, object, etc. is specified for the import.  For example:
```javascript
// a.js
console.log('Side effect');

function foo() {
  console.log('This is the function we want to import');
}

async function initializer() {
  console.log('Here is an unexpected message');
  return Promise.resolve(5);
}

function bar(value) {
  return async function thing() {
    const output = await value;
    console.log('We will not see this');
  };
}

module.exports = {
  foo,
  barRenamed: bar(initializer()),
};
```
```javascript
// b.js
const { foo } = require('./a');
foo();
```
The output of executing `node b.js` is:
```
Side effect
Here is an unexpected message
This is the function we want to import
```
Note that the only import was `foo`, but Javascript evaluated the entire module.  Mocking the exported functions that are causing problems right before importing from the module that those functions exist in will not prevent Javascript from evaluating the entire module.  In the toy example above, mocking `initializer` in `b.js` right before importing `foo` would not prevent Javascript from evaluating the entire `b.js` module (including the original `initializer` call).

### Solution
The offending function was moved to another Javascript module that is then imported into the agent module.  Most importantly, this pattern does not change the functionality of the agent code in production.  For our current issue with tests, this pattern allows us to mock the `initializeTokensContracts` function before the agent module is imported, ensuring that the agent module will then get our mocked version of the function (e.g. a no-op), so that when the agent module is evaluated at import time, no JSON-RPC connections are created, no Promises are unhandled, etc.

The code used to accomplish this is:
```javascript
jest.mock('./agent-setup', () => ({
  ...jest.requireActual('./agent-setup'),
  initializeTokensContracts: jest.fn().mockResolvedValue(),
}));

const { createAlert } = require('./agent-setup');
const { provideHandleBlock } = require('./check-reserve-update-frequency');
```