### PR TITLE
AE-440: Update agent config and consistently use in agents

### DIFF
--- a/agent-config.json
+++ b/agent-config.json
@@ -4,8 +4,8 @@
     "numStds": 2,
     "minElements": 40
   },
-  "anomalous-value" : {
-    "standardDeviation" : 3
+  "anomalousValue" : {
+    "standardDeviations" : 3
   },
   "reserveWatch" : {
     "windowSize": 100,

--- a/src/address-watch/address-watch.js
+++ b/src/address-watch/address-watch.js
@@ -3,6 +3,9 @@ const { Finding, FindingSeverity, FindingType } = require('forta-agent');
 // load config file
 const addressList = require('./address-watch.json');
 
+// load configuration data from agent config file
+const { aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
+
 // get list of addresses to watch
 const addresses = (Object.keys(addressList)).map((a) => a.toLowerCase());
 
@@ -24,7 +27,7 @@ async function handleTransaction(txEvent) {
             from,
             hash,
           },
-          everestId: '0xa3d1fd85c0b62fa8bab6b818ffc96b5ec57602b6',
+          everestId: AAVE_EVEREST_ID,
         }),
       );
     }

--- a/src/address-watch/address-watch.spec.js
+++ b/src/address-watch/address-watch.spec.js
@@ -10,6 +10,9 @@ const {
 // local definitions
 const { handleTransaction, addressList } = require('./address-watch');
 
+// load configuration data from agent config file
+const { aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
+
 /**
  * TransactionEvent(type, network, transaction, receipt, traces, addresses, block)
  */
@@ -57,7 +60,7 @@ describe('watch admin addresses', () => {
             from,
             hash,
           },
-          everestId: '0xa3d1fd85c0b62fa8bab6b818ffc96b5ec57602b6',
+          everestId: AAVE_EVEREST_ID,
         }),
       ]);
     });

--- a/src/admin-events/admin-events.js
+++ b/src/admin-events/admin-events.js
@@ -4,6 +4,8 @@ const { Finding, FindingSeverity, FindingType } = require('forta-agent');
 const contractAddresses = require('../../contract-addresses.json');
 const adminEvents = require('./admin-events.json');
 
+const { aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
+
 // get contract names for mapping to events
 let contractNames = Object.keys(contractAddresses);
 
@@ -47,7 +49,7 @@ async function handleTransaction(txEvent) {
               contractAddress,
               eventName,
             },
-            everestId: '0xa3d1fd85c0b62fa8bab6b818ffc96b5ec57602b6',
+            everestId: AAVE_EVEREST_ID,
           }),
         );
       }

--- a/src/admin-events/admin-events.spec.js
+++ b/src/admin-events/admin-events.spec.js
@@ -13,6 +13,8 @@ const { handleTransaction } = require('./admin-events');
 const lendingPoolAddressProvider = '0xb53c1a33016b2dc2ff3653530bff1848a515c8c5';
 const configurationAdminUpdatedTopic = '0xc20a317155a9e7d84e06b716b4b355d47742ab9f8c5d630e7f556553f582430d';
 
+const { aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
+
 /**
  * TransactionEvent(type, network, transaction, receipt, traces, addresses, block)
  */
@@ -113,7 +115,7 @@ describe('admin event monitoring', () => {
             contractAddress,
             eventName,
           },
-          everestId: '0xa3d1fd85c0b62fa8bab6b818ffc96b5ec57602b6',
+          everestId: AAVE_EVEREST_ID,
         }),
       ]);
     });

--- a/src/anomalous-value/anomalous-value.js
+++ b/src/anomalous-value/anomalous-value.js
@@ -7,6 +7,8 @@ const RollingMath = require('rolling-math');
 const { LendingPool: address } = require('../../contract-addresses.json');
 const { abi } = require('../../abi/ILendingPool.json');
 
+const { anomalousValue, aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
+
 // create ethers interface object
 const iface = new ethers.utils.Interface(abi);
 
@@ -24,7 +26,7 @@ function createAlert(log) {
     alertId: 'AE-AAVE-HIGH-TX-AMOUNT',
     severity: FindingSeverity.Medium,
     type: FindingType.Suspicious,
-    everestId: '0xa3d1fd85c0b62fa8bab6b818ffc96b5ec57602b6',
+    everestId: AAVE_EVEREST_ID,
     metadata: JSON.stringify(log),
   });
 }
@@ -59,8 +61,8 @@ async function handleTransaction(txEvent) {
       const average = rollingEventData[log.args.reserve].getAverage();
       const standardDeviation = rollingEventData[log.args.reserve].getStandardDeviation();
 
-      // limit is 3 standard deviations
-      const limit = average.plus(standardDeviation.times(3));
+      // limit is set from agent-config.json file 
+      const limit = average.plus(standardDeviation.times(anomalousValue.standardDeviations));
       const delta = amount.minus(average).absoluteValue();
 
       // if instance is outside the standard deviation, report

--- a/src/anomalous-value/anomalous-value.js
+++ b/src/anomalous-value/anomalous-value.js
@@ -61,7 +61,7 @@ async function handleTransaction(txEvent) {
       const average = rollingEventData[log.args.reserve].getAverage();
       const standardDeviation = rollingEventData[log.args.reserve].getStandardDeviation();
 
-      // limit is set from agent-config.json file 
+      // limit is set from agent-config.json file
       const limit = average.plus(standardDeviation.times(anomalousValue.standardDeviations));
       const delta = amount.minus(average).absoluteValue();
 

--- a/src/anomalous-value/anomalous-value.spec.js
+++ b/src/anomalous-value/anomalous-value.spec.js
@@ -13,6 +13,8 @@ const { LendingPool: address } = require('../../contract-addresses.json');
 const { abi } = require('../../abi/ILendingPool.json');
 const { handleTransaction } = require('./anomalous-value');
 
+const { aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
+
 // create interface
 const iface = new ethers.utils.Interface(abi);
 
@@ -166,7 +168,7 @@ describe('aave anomalous value agent', () => {
         alertId: 'AE-AAVE-HIGH-TX-AMOUNT',
         severity: FindingSeverity.Medium,
         type: FindingType.Suspicious,
-        everestId: '0xa3d1fd85c0b62fa8bab6b818ffc96b5ec57602b6',
+        everestId: AAVE_EVEREST_ID,
         metadata: JSON.stringify(parsedLog),
       });
 

--- a/src/compare-oracle-to-fallback/agent-setup.js
+++ b/src/compare-oracle-to-fallback/agent-setup.js
@@ -13,7 +13,7 @@ const { abi: protocolDataProviderAbi } = require('../../abi/AaveProtocolDataProv
 const { abi: aaveOracleAbi } = require('../../abi/AaveOracle.json');
 const { abi: priceOracleGetterAbi } = require('../../abi/IPriceOracleGetter.json');
 const { abi: lendingPoolAddressesProviderAbi } = require('../../abi/ILendingPoolAddressesProvider.json');
-const { aaveEverestId } = require('../../agent-config.json');
+const { aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
 
 // set up the an ethers provider
 // do not use ethers.providers.WebSocketProvider in production (there is no support)
@@ -35,7 +35,7 @@ function createAlert(reserveToken, tokenPrice, tokenPriceFallback, percentError,
     alertId: 'AE-AAVE-FALLBACK-ORACLE-DISPARITY',
     severity: FindingSeverity.High,
     type: FindingType.Degraded,
-    everestId: aaveEverestId,
+    everestId: AAVE_EVEREST_ID,
     metadata: {
       symbol: reserveToken.symbol,
       tokenAddress: reserveToken.tokenAddress,

--- a/src/reserve-watch/reserve-watch.js
+++ b/src/reserve-watch/reserve-watch.js
@@ -6,7 +6,10 @@ const ethers = require('ethers');
 const RollingMath = require('rolling-math');
 
 const contractAddresses = require('../../contract-addresses.json');
-const { reserveWatch: config } = require('../../agent-config.json');
+const { 
+  reserveWatch: config,
+  aaveEverestId: AAVE_EVEREST_ID,
+} = require('../../agent-config.json');
 
 const { windowSize, numStds } = config;
 const {
@@ -31,7 +34,7 @@ function createAlert(asset, price) {
     alertId: 'AE-AAVE-RESERVE-PRICE',
     severity: FindingSeverity.Medium,
     type: FindingType.Suspicious,
-    everestId: '0xa3d1fd85c0b62fa8bab6b818ffc96b5ec57602b6',
+    everestId: AAVE_EVEREST_ID,
     metadata: {
       symbol,
       price: ethers.utils.formatEther(price),

--- a/src/reserve-watch/reserve-watch.js
+++ b/src/reserve-watch/reserve-watch.js
@@ -6,7 +6,7 @@ const ethers = require('ethers');
 const RollingMath = require('rolling-math');
 
 const contractAddresses = require('../../contract-addresses.json');
-const { 
+const {
   reserveWatch: config,
   aaveEverestId: AAVE_EVEREST_ID,
 } = require('../../agent-config.json');

--- a/src/total-value-and-liquidity/common.js
+++ b/src/total-value-and-liquidity/common.js
@@ -1,5 +1,5 @@
 const { Finding, FindingSeverity, FindingType } = require('forta-agent');
-const { aaveEverestId } = require('../../agent-config.json');
+const { aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
 
 // data fields the agent is interested in
 const dataFields = [
@@ -18,7 +18,7 @@ function createAlert(data) {
     alertId: 'AE-AAVE-TVL',
     severity: FindingSeverity.High,
     type: FindingType.Suspicious,
-    everestId: aaveEverestId,
+    everestId: AAVE_EVEREST_ID,
     metadata: JSON.stringify(data),
   });
 }

--- a/src/total-value-and-liquidity/total-value-and-liquidity.spec.js
+++ b/src/total-value-and-liquidity/total-value-and-liquidity.spec.js
@@ -123,11 +123,11 @@ describe('liquidity and total value locked agent tests', () => {
       expect(mockRollingMath).toBeCalledWith(mockConfig.windowSize);
     });
 
-    it('standard devation limit', async () => {
+    it('standard deviation limit', async () => {
       // run a block to initialize our data
       await handleTransaction({ blockNumber: 0 });
 
-      // set standard devation limit to a unique and non default number
+      // set standard deviation limit to a unique and non default number
       mockConfig.numStds = 42;
 
       // make our math module return more than minimum required elements
@@ -143,14 +143,14 @@ describe('liquidity and total value locked agent tests', () => {
         jest.fn(() => new BigNumber(1)),
       );
 
-      // ensure observations below standard devation we do not alert
+      // ensure observations below standard deviation we do not alert
       mockData.totalStableDebt = ethers.BigNumber.from(mockConfig.numStds * 1 + 10);
 
       // since we are equal to but not passing the limit we should not get back
       // any findings
       expect(await handleTransaction({ blockNumber: 0 })).toStrictEqual([]);
 
-      // make observations larger than our standard devation limit
+      // make observations larger than our standard deviation limit
       mockData.totalStableDebt = ethers.BigNumber.from(mockConfig.numStds * 1 + 10 + 1);
 
       // since we are outside of the limit, expect a finding
@@ -162,7 +162,7 @@ describe('liquidity and total value locked agent tests', () => {
       await handleTransaction({ blockNumber: 0 });
 
       // set up our observations to be outside of standard deviation range
-      // since default average and standard devation returned is 0, any number will suffice
+      // since default average and standard deviation returned is 0, any number will suffice
       mockData.totalStableDebt = ethers.BigNumber.from(100);
 
       // set number of required elements to an arbitrary value
@@ -186,7 +186,7 @@ describe('liquidity and total value locked agent tests', () => {
       // run a block to initialize our data
       await handleTransaction({ blockNumber: 0 });
 
-      // set our standard devation to be really large so it won't alert
+      // set our standard deviation to be really large so it won't alert
       mockRollingMathFuncs.getStandardDeviation.mockImplementation(
         jest.fn(() => new BigNumber(9001)),
       );
@@ -199,7 +199,7 @@ describe('liquidity and total value locked agent tests', () => {
       // set large number of standard deviations to make the limit large
       mockConfig.numStds = 10;
 
-      // expect a default finding of 0 to not be past the standard devation
+      // expect a default finding of 0 to not be past the standard deviation
       expect(await handleTransaction({ blockNumber: 0 })).toStrictEqual([]);
     });
 
@@ -309,7 +309,7 @@ describe('liquidity and total value locked agent tests', () => {
       // intialize our data fields
       await handleTransaction({ blockNumber: 0 });
 
-      // default standard devation is 0 and average is 0, if we return anything it should alert
+      // default standard deviation is 0 and average is 0, if we return anything it should alert
       mockData.totalStableDebt = ethers.BigNumber.from(9001);
 
       // return large amount of elements


### PR DESCRIPTION
This work standardizes the use of the `agent-config.json` file in Aave agents.  Our conventions for naming the keys in `agent-config.json` and what values belong there have evolved since the initial agents were completed.  This work applies the conventions that we have developed over the course of all agents.

Also, there were some typographical errors to fix.