### PR TITLE
AE: 858 859 861 864 870 - Bug Fixes

### DIFF
--- a/agent-config.json
+++ b/agent-config.json
@@ -5,6 +5,7 @@
     "minElements": 40
   },
   "anomalousValue" : {
+    "windowSize": 10,
     "standardDeviations" : 3
   },
   "reserveWatch" : {

--- a/agent-config.json
+++ b/agent-config.json
@@ -8,9 +8,8 @@
     "standardDeviations" : 3
   },
   "reserveWatch" : {
-    "windowSize": 100,
-    "numStds" : 3,
-    "minElements": 40
+    "windowSize": 10,
+    "numStds" : 3
   },
   "compareOracleToFallback": {
     "aaveOraclePercentErrorThreshold": 2,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bignumber.js": "^9.0.1",
     "dotenv": "^10.0.0",
     "ethers": "^5.4.6",
-    "forta-agent": "^0.0.29",
+    "forta-agent": "^0.0.33",
     "rolling-math": "^0.0.1"
   },
   "devDependencies": {

--- a/src/address-watch/address-watch.js
+++ b/src/address-watch/address-watch.js
@@ -7,7 +7,7 @@ const addressList = require('./address-watch.json');
 const { aaveEverestId: AAVE_EVEREST_ID } = require('../../agent-config.json');
 
 // get list of addresses to watch
-const addresses = (Object.keys(addressList)).map((a) => a.toLowerCase());
+const addresses = Object.keys(addressList);
 
 async function handleTransaction(txEvent) {
   const findings = [];
@@ -15,7 +15,7 @@ async function handleTransaction(txEvent) {
 
   // check if an address in the watchlist was the initiator of the transaction
   addresses.forEach((address) => {
-    if (from === address) {
+    if (from === address.toLowerCase()) {
       findings.push(
         Finding.fromObject({
           name: 'Aave Address Watch',

--- a/src/address-watch/address-watch.spec.js
+++ b/src/address-watch/address-watch.spec.js
@@ -64,5 +64,34 @@ describe('watch admin addresses', () => {
         }),
       ]);
     });
+
+    it('returns a finding if the transaction originator is on the watch list and contains a mix of uppercase and lowercase letters in its address', async () => {
+      // build txEvent
+      const fromAddress = '0x504b0B9B2fa7fEb434820058061f73E7e86ed38A';
+      const txEvent = createTxEvent({
+        from: fromAddress.toLowerCase(),
+        hash: ethers.constants.HashZero,
+      });
+
+      // run agent with txEvent
+      const findings = await handleTransaction(txEvent);
+      const { from, hash } = txEvent.transaction;
+
+      // assertions
+      expect(findings).toStrictEqual([
+        Finding.fromObject({
+          name: 'Aave Address Watch',
+          description: `Address ${fromAddress} (${addressList[fromAddress]}) was involved in a transaction`,
+          alertId: 'AE-AAVE-ADDRESS-WATCH',
+          type: FindingType.Suspicious,
+          severity: FindingSeverity.Low,
+          metadata: {
+            from,
+            hash,
+          },
+          everestId: AAVE_EVEREST_ID,
+        }),
+      ]);
+    });
   });
 });

--- a/src/anomalous-value/anomalous-value.js
+++ b/src/anomalous-value/anomalous-value.js
@@ -24,16 +24,18 @@ const eventFragments = [
 const rollingEventData = {};
 
 // helper function to create alerts
-function createAlert(log, txEvent) {
+function createAlert(log) {
   return Finding.fromObject({
     name: `High AAVE ${log.name} Amount`,
-    description: `${log.name}: ${log.args.amount.toString()}\nToken: ${log.args.reserve}`,
+    description: `A transaction utilized a large amount of ${log.args.reserve}`,
     alertId: 'AE-AAVE-HIGH-TX-AMOUNT',
     severity: FindingSeverity.Medium,
     type: FindingType.Suspicious,
     everestId: AAVE_EVEREST_ID,
     metadata: {
-      txHash: txEvent.hash,
+      event: log.name,
+      amount: log.args.amount.toString(),
+      token: log.args.reserve,
     },
   });
 }
@@ -65,7 +67,7 @@ async function handleTransaction(txEvent) {
 
       // if instance is outside the standard deviation, report
       if (delta.isGreaterThan(limit)) {
-        findings.push(createAlert(log, txEvent));
+        findings.push(createAlert(log));
       }
     }
 

--- a/src/anomalous-value/anomalous-value.spec.js
+++ b/src/anomalous-value/anomalous-value.spec.js
@@ -116,7 +116,7 @@ function createReceipt(logs, contractAddress) {
  * TransactionEvent(type, network, transaction, receipt, traces, addresses, block)
  */
 function createTxEvent(receipt, addresses) {
-  return new TransactionEvent(null, null, { hash: '0xTEST' }, receipt, [], addresses, null);
+  return new TransactionEvent(null, null, null, receipt, [], addresses, null);
 }
 
 // tests
@@ -169,13 +169,15 @@ describe('aave anomalous value agent', () => {
       // create expected finding
       const expectedFinding = Finding.fromObject({
         name: 'High AAVE Borrow Amount',
-        description: `Borrow: ${largeAmount}\nToken: ${tokenA}`,
+        description: `A transaction utilized a large amount of ${tokenA}`,
         alertId: 'AE-AAVE-HIGH-TX-AMOUNT',
         severity: FindingSeverity.Medium,
         type: FindingType.Suspicious,
         everestId: AAVE_EVEREST_ID,
         metadata: {
-          txHash: '0xTEST',
+          event: 'Borrow',
+          amount: `${largeAmount}`,
+          token: tokenA,
         },
       });
 

--- a/src/new-contract-interaction/new-contract-interaction.js
+++ b/src/new-contract-interaction/new-contract-interaction.js
@@ -133,11 +133,11 @@ function provideHandleTransaction(ethersProvider, protocolDataProvider) {
         const codePromise = ethersProvider.getCode(address);
 
         // associate each address with the code that was returned
-        codePromise.then((result) => contractCode.push({ address, code: result }));
-
-        // to prevent Promise.all() from rejecting, catch failed promises and set the return
-        // value to undefined
-        contractCodePromises.push(codePromise.catch(() => undefined));
+        codePromise
+          .then((result) => contractCode.push({ address, code: result }))
+          // to prevent Promise.all() from rejecting, catch failed promises and set the return
+          // value to undefined
+          .catch(() => contractCodePromises.push(undefined));
       });
 
       // wait for the promises to be settled
@@ -155,11 +155,11 @@ function provideHandleTransaction(ethersProvider, protocolDataProvider) {
         const txlistPromise = axios.get(BASE_URL + item.address + OPTIONS + API_KEY);
 
         // associate each address with the transaction list that was returned
-        txlistPromise.then((result) => txData.push({ address: item.address, response: result }));
-
-        // to prevent Promise.all() from rejecting, catch failed promises and set the return
-        // value to undefined
-        etherscanTxlistPromises.push(txlistPromise.catch(() => undefined));
+        txlistPromise
+          .then((result) => txData.push({ address: item.address, response: result }))
+          // to prevent Promise.all() from rejecting, catch failed promises and set the return
+          // value to undefined
+          .catch(() => etherscanTxlistPromises.push(undefined));
       });
 
       // wait for the promises to be settled


### PR DESCRIPTION
This PR addresses several bugs found in the AAVE agent suite:

1. AE-858 - new contract interaction agent tests were failing intermittently

2. AE-859 - address watch agent findings sometimes contained 'undefined' values

3. AE-861 - reserve watch agent was spamming findings with the same (or very similar) values

4. AE-864 - anomalous value agent was not correctly calculating if a value is outside N standard deviations

5. AE-870 - new contract interaction agent was not chaining promises correctly

Additionally, the anomalous value agent was updated to use forta-agent's built in filterLog function and the metadata was updated to return the transaction hash instead of the log as a string (transaction hash can be used to lookup the logs).